### PR TITLE
Modify modules that depends of message_post_model to make them match with the new version

### DIFF
--- a/purchase_console/__openerp__.py
+++ b/purchase_console/__openerp__.py
@@ -62,6 +62,7 @@
         'views/purchase_requisition_view.xml',
         'views/layout.xml',
         'wizard/fill_products_wizard_view.xml',
+        'data/data.xml',
     ],
     "demo": [
     ],

--- a/purchase_console/data/data.xml
+++ b/purchase_console/data/data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <function model="ir.model" name="_add_write_patch_model">
+            <function eval="[[('model', '=', 'purchase.requisition')]]" model="ir.model" name="search"/>
+        </function>
+
+    </data>
+</openerp>

--- a/purchase_console/models/requisition.py
+++ b/purchase_console/models/requisition.py
@@ -15,8 +15,7 @@ from openerp import _, api, fields, models
 
 
 class PurchaseRequisition(models.Model):
-    _name = 'purchase.requisition'
-    _inherit = ['purchase.requisition', 'message.post.show.all']
+    _inherit = 'purchase.requisition'
     _excluded_states_po = ['cancel']
 
     @api.model


### PR DESCRIPTION
The modules that need to be updated are:

```
purchase_console
```

This change is made to make it match with https://github.com/Vauxoo/addons-vauxoo/pull/1075